### PR TITLE
fix add-apt-repository

### DIFF
--- a/devuan/ascii/howto
+++ b/devuan/ascii/howto
@@ -224,7 +224,6 @@ EOF
 
 cat <<EOF > /usr/share/python-apt/templates/Devuan.mirrors
 http://pkgmaster.devuan.org
-http://deb.devuan.org
 EOF
 
 ## Remove installed locales:


### PR DESCRIPTION
http://deb.devuan.org break add-apt-repository.

It fails with:
Traceback (most recent call last):
  File "/usr/bin/add-apt-repository", line 95, in <module>
    sp = SoftwareProperties(options=options)
  File "/usr/lib/python3/dist-packages/softwareproperties/SoftwareProperties.py", line 103, in __init__
    self.sourceslist = SourcesList()
  File "/usr/lib/python3/dist-packages/aptsources/sourceslist.py", line 276, in __init__
    self.refresh()
  File "/usr/lib/python3/dist-packages/aptsources/sourceslist.py", line 291, in refresh
    self.matcher.match(source)
  File "/usr/lib/python3/dist-packages/aptsources/sourceslist.py", line 475, in match
    elif (template.is_mirror(source.uri) and
  File "/usr/lib/python3/dist-packages/aptsources/distinfo.py", line 63, in is_mirror
    return self.mirror_set[hostname].has_repository(proto, dir)
  File "/usr/lib/python3/dist-packages/aptsources/distinfo.py", line 119, in has_repository
    if r.proto == proto and dir in r.dir:



Signed-off-by: Kaut Maksim <maksimkaut92@gmail.com>